### PR TITLE
Change grains['manufacture'] to grains['manufacturer'] for Solaris

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2540,7 +2540,7 @@ def _hw_data(osdata):
             ]
         ]
 
-        manufacture_regexes = [
+        manufacturer_regexes = [
             re.compile(r) for r in [
                 r'(?im)^\s*System\s+Configuration:\s*(.*)(?=sun)',  # prtdiag
             ]
@@ -2608,10 +2608,10 @@ def _hw_data(osdata):
                 grains['uuid'] = res.group(1).strip().replace("'", "")
                 break
 
-        for regex in manufacture_regexes:
+        for regex in manufacturer_regexes:
             res = regex.search(data)
             if res and len(res.groups()) >= 1:
-                grains['manufacture'] = res.group(1).strip().replace("'", "")
+                grains['manufacturer'] = res.group(1).strip().replace("'", "")
                 break
 
         for regex in product_regexes:


### PR DESCRIPTION
This appears to be a typo, as for all other OS's, it is 'manufacturer'.

### What does this PR do?
Renames the 'manufacture' grain to 'manufacturer' on Solaris, for consistency with Linux, etc.

### What issues does this PR fix or reference?

### Previous Behavior
grains['manufacture'] == 'Oracle Corporation'

### New Behavior
grains['manufacturer'] == 'Oracle Corporation'

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
